### PR TITLE
Add QSAutomation.[Status] table.  The contents are static and not use…

### DIFF
--- a/QueryStoreAutomation_Step0_SetupTables.sql
+++ b/QueryStoreAutomation_Step0_SetupTables.sql
@@ -17,6 +17,16 @@ DROP TABLE IF EXISTS QSAutomation.ActivityLog
 DROP TABLE IF EXISTS QSAutomation.Query
 GO
 
+--The list of StatusID to description mappings
+DROP TABLE IF EXISTS QSAutomation.[Status]
+GO
+
+CREATE TABLE QSAutomation.[Status] (
+	StatusID tinyint
+	, StatusDescription VARCHAR(500)
+)
+GO
+
 CREATE TABLE QSAutomation.Query (
 	QueryID bigint NOT NULL CONSTRAINT PK_Query PRIMARY KEY
 	, QueryHash binary(8)
@@ -55,7 +65,24 @@ VALUES (1, 'Query Unlock Start Time', NULL)
 	 , (4, 't-Statistic Threshold', '100')
 	 , (5, 'DF Threshold', '10')
 	 , (6, 'High Variation Duration Threshold (MS)', '500')
-	 , (7, 'Mono Plan Performance Threshold (ms)', '30000')
+	 , (7, 'Mono Plan Performance Threshold (ms)', '2000')
 	 , (8, 'Notification Email Address', 'chad.crawford@henryschein.com')
 	 , (9, 'Email Log Level', 'Error') --Error, Warn, Info, Debug
+GO
+
+--List Status Descriptions.  This isn't used in code, but is a convenient reference for those using the tool
+INSERT INTO QSAutomation.[Status] 
+VALUES (0,  'Never Unlocked.  Queries with this StatusID always keep the pinned plan as long as it remains a valid plan.  These are queries we have hand-selected a plan for, or are volatile and cause issues.  We do not want any accidental changes to happen to these plans.')
+	 , (1,  'New query.  This query has been pinned for less than 1 day')
+	 , (2,  'Stage 1.  This query has been pinned for less than 1 week + 1 day')
+	 , (3,  'Stage 2.  This query has been pinned for less than 3 weeks + 1 day')
+	 , (4,  'Stage 3.  This query has been pinned for less than 5 weeks + 1 day')
+	 , (11, 'New query unlocked temporarily to see if we can find a better plan')
+	 , (12, 'Stage 1 query unlocked temporarily to see if we can find a better plan')
+	 , (13, 'Stage 2 query unlocked temporarily to see if we can find a better plan')
+	 , (14, 'Stage 3 query unlocked temporarily to see if we can find a better plan')
+	 , (20, 'Mono-plan temporarily unlocked.  A mono-plan query is a long-running query that does not have a high variation in plan performance.  In other words, there isn''t a "really good" nor a "really bad" plan, the query just always seems to run long.  Queries with a StatusID of 20 regularly have any cached plans flushed to encourage new plans to surface.  As soon as a better plan surfaces, the High Variation Check grabs the better plan and pins it.')
+	 , (30, 'Always unlocked.  Queries in this state are undergoing long-term searches for better plans and regularly have any cached plans flushed in order to encourage new plans to surface.')
+	 , (40, 'Stable plans.  A stable plan is one that has either gone through the 5 week unlock cycle and we have the best plan available, or a mono-plan query that was unlocked and flushed, but no better plan was found.  These queries are no longer unlocked, but they are still considered during the High Variation Check and updated if new, better plans are found.')
+
 GO

--- a/QueryStoreAutomation_Step5_PoorPerformingMonoPlanCheck.sql
+++ b/QueryStoreAutomation_Step5_PoorPerformingMonoPlanCheck.sql
@@ -151,7 +151,7 @@ BEGIN
 	IF EXISTS (SELECT * FROM #UnresolvedMonoPlans)
 	BEGIN
 		UPDATE QSAutomation.Query 
-		SET StatusID = 0
+		SET StatusID = 40
 		FROM QSAutomation.Query 
 		INNER JOIN #UnresolvedMonoPlans ON Query.QueryID = #UnresolvedMonoPlans.QueryID
 	


### PR DESCRIPTION
Add QSAutomation.[Status] table.  The contents are static and not used in code, but is a convenient reference for those using the tool.

Split StatusID 0 into two statuses:  0 (manually pinned by DBA) and 40 (best plan found)

High variation check now only skips status 0 and 30, and considers all other statuses.

Lowered the Default Mono Plan Performance Threshold to 2000ms

Lowered the Mono Plan execution count minimum to 5.  Prior to this it was set to 100.  This issue with this high number is that queries with multiple plans but only one plan with >100 executions appeared to be mono-plan when they really were not.  Lowering the threshold helps with this issue, and allowing mono-plans (StatusID 40) to be evaluated by the High Variation Check ensures that mono-plans are re-evaluated regularly.

Sending an email when the Query Store is reset is controlled by the log level now instead of on an incremental basis.

When preparing to unpin a plan to allow new ones to form, check first to make sure the plan is still pinned (otherwise you will get an error)